### PR TITLE
alerts for consent not given

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -19,3 +19,4 @@ import "phoenix_html"
 // paths "./socket" or full ones "web/static/js/socket".
 
 // import socket from "./socket"
+import "./consent.js"

--- a/web/static/js/consent.js
+++ b/web/static/js/consent.js
@@ -1,0 +1,48 @@
+module.exports = (function() {
+  var noConsent = document.querySelectorAll(".no-consent");
+  var yesConsent = document.querySelectorAll(".yes-consent");
+
+  noConsent.forEach(function(el){
+    el.addEventListener("click", function (e) {
+      var index = e.target.id[e.target.id.length - 1];
+      document.getElementById("error-consent-" + index).classList.remove("dn");
+      checkAllAnswered();
+    });
+  });
+
+  yesConsent.forEach(function(el, i, a){
+    el.addEventListener("click", function (e) {
+      var index = e.target.id[e.target.id.length - 1];
+      document.getElementById("error-consent-" + index).classList.add("dn");
+      checkAllAnswered();
+    });
+  });
+})();
+
+function checkAllAnswered() {
+  var checked = document.querySelectorAll("input.yes-consent[type=radio]:checked");
+  var count = document.querySelectorAll(".yes-consent");
+
+  if (checked.length === count.length) {
+    nextButton('active');
+  } else {
+    nextButton('inactive')
+  }
+}
+
+function nextButton (state) {
+  var nextActive = document.querySelector("#next-active");
+  var nextInactive = document.querySelector("#next-inactive");
+
+  if (state === 'active') {
+    nextActive.classList.remove('dn');
+    nextActive.classList.add('dib');
+    nextInactive.classList.remove('dib');
+    nextInactive.classList.add('dn');
+  } else if (state === 'inactive') {
+    nextInactive.classList.remove('dn');
+    nextInactive.classList.add('dib');
+    nextActive.classList.remove('dib');
+    nextActive.classList.add('dn');
+  }
+}

--- a/web/static/js/consent.js
+++ b/web/static/js/consent.js
@@ -2,7 +2,7 @@ module.exports = (function() {
   var noConsent = document.querySelectorAll(".no-consent");
   var yesConsent = document.querySelectorAll(".yes-consent");
 
-  noConsent.forEach(function(el){
+[].forEach.call(noConsent, function(el){
     el.addEventListener("click", function (e) {
       var index = e.target.id[e.target.id.length - 1];
       document.getElementById("error-consent-" + index).classList.remove("dn");
@@ -10,7 +10,7 @@ module.exports = (function() {
     });
   });
 
-  yesConsent.forEach(function(el, i, a){
+[].forEach.call(yesConsent, function(el, i, a){
     el.addEventListener("click", function (e) {
       var index = e.target.id[e.target.id.length - 1];
       document.getElementById("error-consent-" + index).classList.add("dn");

--- a/web/static/js/consent.js
+++ b/web/static/js/consent.js
@@ -1,23 +1,21 @@
-module.exports = (function() {
-  var noConsent = document.querySelectorAll(".no-consent");
-  var yesConsent = document.querySelectorAll(".yes-consent");
+var noConsent = document.querySelectorAll(".no-consent");
+var yesConsent = document.querySelectorAll(".yes-consent");
 
 [].forEach.call(noConsent, function(el){
-    el.addEventListener("click", function (e) {
-      var index = e.target.id[e.target.id.length - 1];
-      document.getElementById("error-consent-" + index).classList.remove("dn");
-      checkAllAnswered();
-    });
+  el.addEventListener("click", function (e) {
+    var index = e.target.id[e.target.id.length - 1];
+    document.getElementById("error-consent-" + index).classList.remove("dn");
+    checkAllAnswered();
   });
+});
 
 [].forEach.call(yesConsent, function(el, i, a){
-    el.addEventListener("click", function (e) {
-      var index = e.target.id[e.target.id.length - 1];
-      document.getElementById("error-consent-" + index).classList.add("dn");
-      checkAllAnswered();
-    });
+  el.addEventListener("click", function (e) {
+    var index = e.target.id[e.target.id.length - 1];
+    document.getElementById("error-consent-" + index).classList.add("dn");
+    checkAllAnswered();
   });
-})();
+});
 
 function checkAllAnswered() {
   var checked = document.querySelectorAll("input.yes-consent[type=radio]:checked");

--- a/web/templates/consent/new.html.eex
+++ b/web/templates/consent/new.html.eex
@@ -50,18 +50,30 @@
           </p>
         </div>
         <div class="dib v-mid">
-          <%= radio_button f, String.to_atom(question["field_name"]), "Yes"%>
+          <%= radio_button f, String.to_atom(question["field_name"]), "Yes", class: "yes-consent", id: "yes-consent-#{i+1}" %>
           <%= label f, question["field_name"], "Yes" %>
-          <%= radio_button f, String.to_atom(question["field_name"]), "No" %>
+          <%= radio_button f, String.to_atom(question["field_name"]), "No", class: "no-consent", id: "no-consent-#{i+1}" %>
           <%= label f, question["field_name"], "No" %>
+        </div>
+        <div id="error-consent-<%= i+1 %>" class="pl3 mh5 dn bg-light-pink w-80 br-pill">
+          <div class="v-mid dib br-100 h3 w3 bg-white tc pt1">
+            <span class="f1">!</span>
+          </div>
+          <div class="dib v-mid ph4 pv1">
+            <p>
+              If you do not consent to this option, you will not be able to join the Research Resource
+            </p>
+            <p>
+              If you are unsure, why not give us a call to talk it through - or <a href="#">request a call back</a>
+            </p>
+          </div>
         </div>
       </div>
     </div>
   <% end %>
   <div class="pa3 ph5">
-    <%= submit "Next", class: "mr3 bn f6 link dim br-pill ph3 pv2 mb2 dib white bg-blue pointer" %>
+    <%= submit "Next", class: "mr3 bn f6 link dim br-pill ph3 pv2 mb2 white bg-blue dn", id: "next-active" %>
+    <%= submit "You cannot complete registration", class: "mr3 bn f6 link dim br-pill ph3 pv2 mb2 dib white bg-grey", id: "next-inactive" %>
     <%= link "Cancel", to: "#", class: "dib" %>
   </div>
 <% end %>
-
-


### PR DESCRIPTION
ref #14 
Uses javascript to add alerts and disable next button if any consent question is answered 'no'. 

When we hook up the submitting of the questions to redcap we'll add backend checks to ensure those with javascript disabled see the alerts/cannot continue