### PR TITLE
force rebuild on heroku

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,1 @@
+always_rebuild=true


### PR DESCRIPTION
see #232

It seems that Heroku hasn't rebuild completely the project as the old image is still displayed on the website. I think this should force Heroku to rebuild each time, see also http://www.phoenixframework.org/docs/heroku at the end of the page